### PR TITLE
Fix implicit type conversion

### DIFF
--- a/germandecomp/germandecomp.c
+++ b/germandecomp/germandecomp.c
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
   putchar('\n');
   FILE* output;
   output = fopen(argv[2], "w");
-  char c;
+  int c;
   while((c = fgetc(input)) != EOF) {
     for(int i = 7; i >= 0; i--) {
       if(c & (1 << i))


### PR DESCRIPTION
When assigning the `fgetc` result to `c`, which is a char, there is a potential loss of information. This results in a decompilation failure of files containing a `0xff` byte which gets interpreted as `EOF`.